### PR TITLE
update home page to point to a git project

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   ],
   "author": "SAP SE (https://www.sap.com)",
   "license": "SEE LICENSE IN LICENSE",
-  "homepage": "https://cap.cloud.sap/",
+  "homepage": "https://github.com/cap-js/cds-adapter-graphql",
   "main": "index.js",
   "files": [
     "lib/",


### PR DESCRIPTION
Currently this page https://www.npmjs.com/package/@sap/cds-graphql doesn't have any reference to a project page.
I knew about this project only from a shared link. 
So may be if we update a homepage for this module - contributors may come here directly from npm - not from the documentation page.