### PR TITLE
fix: server crash if "localized" is used as property name

### DIFF
--- a/lib/schema/util/index.js
+++ b/lib/schema/util/index.js
@@ -3,7 +3,7 @@ const hasScalarFields = entity =>
     ([, el]) => !(shouldElementBeIgnored(el) || el.isAssociation || el.isComposition)
   )
 
-const _isLocalized = element => element.name === 'localized' && element.target.endsWith('.texts')
+const _isLocalized = element => element.name === 'localized' && element.target && element.target.endsWith('.texts')
 
 const shouldElementBeIgnored = element => element.name.startsWith('up_') || _isLocalized(element)
 

--- a/test/resources/bookshop-graphql/db/schema.cds
+++ b/test/resources/bookshop-graphql/db/schema.cds
@@ -9,7 +9,8 @@ extend bookshop.Books with {
 }
 
 entity Chapters : managed {
-  key book   : Association to bookshop.Books;
-  key number : Integer;
-      title  : String;
+  key book      : Association to bookshop.Books;
+  key number    : Integer;
+      title     : String;
+      localized : String; // to test that a property only named 'localized' is not confused with localized keyword
 }

--- a/test/schemas/bookshop-graphql.gql
+++ b/test/schemas/bookshop-graphql.gql
@@ -321,6 +321,7 @@ type AdminService_Chapters {
   book_ID: Int
   createdAt: Timestamp
   createdBy: String
+  localized: String
   modifiedAt: Timestamp
   modifiedBy: String
   number: Int
@@ -332,6 +333,7 @@ input AdminService_Chapters_C {
   book_ID: Int
   createdAt: Timestamp
   createdBy: String
+  localized: String
   modifiedAt: Timestamp
   modifiedBy: String
   number: Int
@@ -343,6 +345,7 @@ input AdminService_Chapters_U {
   book_ID: Int
   createdAt: Timestamp
   createdBy: String
+  localized: String
   modifiedAt: Timestamp
   modifiedBy: String
   number: Int
@@ -358,6 +361,7 @@ input AdminService_Chapters_filter {
   book_ID: [Int_filter]
   createdAt: [Timestamp_filter]
   createdBy: [String_filter]
+  localized: [String_filter]
   modifiedAt: [Timestamp_filter]
   modifiedBy: [String_filter]
   number: [Int_filter]
@@ -381,6 +385,7 @@ input AdminService_Chapters_orderBy {
   book_ID: SortDirection
   createdAt: SortDirection
   createdBy: SortDirection
+  localized: SortDirection
   modifiedAt: SortDirection
   modifiedBy: SortDirection
   number: SortDirection
@@ -866,6 +871,7 @@ type CatalogService_Chapters {
   book_ID: Int
   createdAt: Timestamp
   createdBy: String
+  localized: String
   modifiedAt: Timestamp
   modifiedBy: String
   number: Int
@@ -877,6 +883,7 @@ input CatalogService_Chapters_C {
   book_ID: Int
   createdAt: Timestamp
   createdBy: String
+  localized: String
   modifiedAt: Timestamp
   modifiedBy: String
   number: Int
@@ -888,6 +895,7 @@ input CatalogService_Chapters_U {
   book_ID: Int
   createdAt: Timestamp
   createdBy: String
+  localized: String
   modifiedAt: Timestamp
   modifiedBy: String
   number: Int
@@ -903,6 +911,7 @@ input CatalogService_Chapters_filter {
   book_ID: [Int_filter]
   createdAt: [Timestamp_filter]
   createdBy: [String_filter]
+  localized: [String_filter]
   modifiedAt: [Timestamp_filter]
   modifiedBy: [String_filter]
   number: [Int_filter]
@@ -926,6 +935,7 @@ input CatalogService_Chapters_orderBy {
   book_ID: SortDirection
   createdAt: SortDirection
   createdBy: SortDirection
+  localized: SortDirection
   modifiedAt: SortDirection
   modifiedBy: SortDirection
   number: SortDirection


### PR DESCRIPTION
This PR fixes a server crash at startup if "localized" is used as property name.

```
INTERNAL ERROR] TypeError: Cannot read properties of undefined (reading 'endsWith')
    at _isLocalized (XXX/node_modules/@cap-js/graphql/lib/schema/util/index.js:6:80)
```