### PR TITLE
feat: register alias field resolver in schema generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Register alias field resolver during schema generation instead of providing to the middleware to pass to the execute function
+
 ### Fixed	
 
 - Fixed a server crash that occourred if an entity property is named `localized`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Register alias field resolver during schema generation instead of providing to the middleware to pass to the execute function
+- Register `aliasFieldResolver` during schema generation instead of passing it to the GraphQL server
 
 ### Fixed	
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,11 +1,10 @@
 const { graphqlHTTP } = require('express-graphql')
 
 const { generateSchema4 } = require('./schema')
-const { fieldResolver } = require('./resolvers')
 
 function GraphQLAdapter(services, options) {
   const schema = generateSchema4(services)
-  return graphqlHTTP({ fieldResolver, schema, ...options })
+  return graphqlHTTP({ schema, ...options })
 }
 
 module.exports = GraphQLAdapter

--- a/lib/resolvers/field.js
+++ b/lib/resolvers/field.js
@@ -1,5 +1,19 @@
+const { isObjectType, isIntrospectionType } = require('graphql')
+
 // The GraphQL.js defaultFieldResolver does not support returning aliased values that resolve to fields with aliases
-module.exports = (source, args, context, info) => {
+function aliasFieldResolver(source, args, contextValue, info) {
   const responseKey = info.fieldNodes[0].alias ? info.fieldNodes[0].alias.value : info.fieldName
   return source[responseKey]
 }
+
+const registerAliasFieldResolvers = schema => {
+  for (const type of Object.values(schema.getTypeMap())) {
+    if (!isObjectType(type) || isIntrospectionType(type)) continue
+
+    for (const field of Object.values(type.getFields())) {
+      if (!field.resolve) field.resolve = aliasFieldResolver
+    }
+  }
+}
+
+module.exports = registerAliasFieldResolvers

--- a/lib/resolvers/index.js
+++ b/lib/resolvers/index.js
@@ -1,7 +1,7 @@
-const fieldResolver = require('./field')
+const registerAliasFieldResolvers = require('./field')
 const createRootResolvers = require('./root')
 
 module.exports = {
-  fieldResolver,
+  registerAliasFieldResolvers,
   createRootResolvers
 }

--- a/lib/schema/index.js
+++ b/lib/schema/index.js
@@ -1,7 +1,7 @@
 const queryGenerator = require('./query')
 const mutationGenerator = require('./mutation')
 const { GraphQLSchema, printSchema } = require('graphql')
-const { createRootResolvers } = require('../resolvers')
+const { createRootResolvers, registerAliasFieldResolvers } = require('../resolvers')
 
 class SchemaGenerator {
   generate(services) {
@@ -10,6 +10,7 @@ class SchemaGenerator {
     const query = queryGenerator(cache).generateQueryObjectType(services, resolvers.Query)
     const mutation = mutationGenerator(cache).generateMutationObjectType(services, resolvers.Mutation)
     this._schema = new GraphQLSchema({ query, mutation })
+    registerAliasFieldResolvers(this._schema)
     return this
   }
 


### PR DESCRIPTION
Allows the GraphQL server framework to be exchanged more easily since the generated GraphQL schema is now fully self-contained. This means it is now also possible to execute queries that contain aliases on the schema directly (without a server) without explicitly providing the `fieldResolver` `ExecutionArgs` property to the `execute` function.