### PR TITLE
fix: add `app` folder to `package.json` for publishing to `npm`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Add `app` folder to `files` property of `package.json` to be included for publishing to `npm`
+
 ### Removed
 
 ## Version 0.3.0 - 2023-02-27

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "homepage": "https://cap.cloud.sap/",
   "main": "index.js",
   "files": [
+    "app/",
     "lib/",
     "index.js",
     "README.md",


### PR DESCRIPTION
fixes https://github.com/cap-js/cds-adapter-graphql/issues/49