### PR TITLE
fix: use `cds.entities(<namespace>)`

### DIFF
--- a/test/resources/bookshop/srv/cat-service.js
+++ b/test/resources/bookshop/srv/cat-service.js
@@ -2,7 +2,7 @@ const cds = require('@sap/cds')
 
 class CatalogService extends cds.ApplicationService { init(){
 
-  const { Books } = this.entities ('sap.capire.bookshop')
+  const { Books } = cds.entities ('sap.capire.bookshop')
 
   // Reduce stock of ordered books if available stock suffices
   this.on ('submitOrder', async req => {


### PR DESCRIPTION
... to get definitions not exposed by the current service (i.e., `this`)