### PR TITLE
chore: adapt changelog for 0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Version 0.14.0 - tbd
-
-### Added
+## Version 0.14.0 - 2025-10-24
 
 ### Changed
 
@@ -18,8 +16,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Sanitization of logged queries, when running in production, if literal values contain parentheses
 - Read GraphiQL HTML file only once on startup, and only if GraphiQL is enabled, to avoid unnecessary file system access
 - Server crash by `SyntaxError` from express JSON parser
-
-### Removed
 
 ## Version 0.13.0 - 2025-07-11
 


### PR DESCRIPTION
Updated version number and release date for 0.14.0. Modified changelog sections to reflect recent changes.