### PR TITLE
chore: prepare for trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
 
@@ -19,7 +20,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: 20
+        node-version: 24
         registry-url: https://registry.npmjs.org/
     - run: npm i
     - run: npm test


### PR DESCRIPTION
Allows token-less publishing.
See https://docs.npmjs.com/trusted-publishers