### PR TITLE
chore: don't overwrite Axios headers

### DIFF
--- a/test/tests/graphiql.test.js
+++ b/test/tests/graphiql.test.js
@@ -6,9 +6,7 @@ describe('graphql - GraphiQL', () => {
   const { axios, GET } = cds.test(path.join(__dirname, '../resources/bookshop-graphql'))
   // Prevent axios from throwing errors for non 2xx status codes
   axios.defaults.validateStatus = false
-  axios.defaults.headers = {
-    authorization: 'Basic YWxpY2U6'
-  }
+  axios.defaults.headers.Authorization = 'Basic YWxpY2U6'
 
   test('GET request to endpoint should serve HTML containing GraphiQL', async () => {
     const response = await GET('/graphql')

--- a/test/tests/http.test.js
+++ b/test/tests/http.test.js
@@ -26,7 +26,7 @@ describe('GraphQL express json parser error scenario', () => {
       })
     } catch (err) {
       expect(err.status).toBe(400)
-      expect(err.response.data.error.message).toMatch(/not valid JSON/)
+      expect(err.response.data.error.message).toMatch(/JSON/i)
       expect(_format(_error[0])).toContain('InvalidJSON')
     }
   })

--- a/test/tests/localized.test.js
+++ b/test/tests/localized.test.js
@@ -6,9 +6,7 @@ describe('graphql - queries with localized data', () => {
   const { axios, POST, data } = cds.test(path.join(__dirname, '../resources/bookshop-graphql'))
   // Prevent axios from throwing errors for non 2xx status codes
   axios.defaults.validateStatus = false
-  axios.defaults.headers = {
-    authorization: 'Basic YWxpY2U6'
-  }
+  axios.defaults.headers.Authorization = 'Basic YWxpY2U6'
 
   beforeEach(async () => {
     await data.reset()

--- a/test/tests/mutations/create.test.js
+++ b/test/tests/mutations/create.test.js
@@ -6,9 +6,7 @@ describe('graphql - create mutations', () => {
   const { axios, POST, data } = cds.test(path.join(__dirname, '../../resources/bookshop-graphql'))
   // Prevent axios from throwing errors for non 2xx status codes
   axios.defaults.validateStatus = false
-  axios.defaults.headers = {
-    authorization: 'Basic YWxpY2U6'
-  }
+  axios.defaults.headers.Authorization = 'Basic YWxpY2U6'
 
   beforeEach(async () => {
     await data.reset()

--- a/test/tests/mutations/delete.test.js
+++ b/test/tests/mutations/delete.test.js
@@ -6,9 +6,7 @@ describe('graphql - delete mutations', () => {
   const { axios, POST, data } = cds.test(path.join(__dirname, '../../resources/bookshop-graphql'))
   // Prevent axios from throwing errors for non 2xx status codes
   axios.defaults.validateStatus = false
-  axios.defaults.headers = {
-    authorization: 'Basic YWxpY2U6'
-  }
+  axios.defaults.headers.Authorization = 'Basic YWxpY2U6'
 
   beforeEach(async () => {
     await data.reset()

--- a/test/tests/mutations/update.test.js
+++ b/test/tests/mutations/update.test.js
@@ -6,9 +6,7 @@ describe('graphql - update mutations', () => {
   const { axios, POST, data } = cds.test(path.join(__dirname, '../../resources/bookshop-graphql'))
   // Prevent axios from throwing errors for non 2xx status codes
   axios.defaults.validateStatus = false
-  axios.defaults.headers = {
-    authorization: 'Basic YWxpY2U6'
-  }
+  axios.defaults.headers.Authorization = 'Basic YWxpY2U6'
 
   beforeEach(async () => {
     await data.reset()

--- a/test/tests/queries/aliases.test.js
+++ b/test/tests/queries/aliases.test.js
@@ -6,9 +6,7 @@ describe('graphql - aliases', () => {
   const { axios, POST } = cds.test(path.join(__dirname, '../../resources/bookshop-graphql'))
   // Prevent axios from throwing errors for non 2xx status codes
   axios.defaults.validateStatus = false
-  axios.defaults.headers = {
-    authorization: 'Basic YWxpY2U6'
-  }
+  axios.defaults.headers.Authorization = 'Basic YWxpY2U6'
 
   // REVISIT: unskip for support of configurable schema flavors
   describe.skip('queries with aliases without connections', () => {

--- a/test/tests/queries/filter.test.js
+++ b/test/tests/queries/filter.test.js
@@ -6,9 +6,7 @@ describe('graphql - filter', () => {
   const { axios, POST, data } = cds.test(path.join(__dirname, '../../resources/bookshop-graphql'))
   // Prevent axios from throwing errors for non 2xx status codes
   axios.defaults.validateStatus = false
-  axios.defaults.headers = {
-    authorization: 'Basic YWxpY2U6'
-  }
+  axios.defaults.headers.Authorization = 'Basic YWxpY2U6'
 
   beforeEach(async () => {
     await data.reset()

--- a/test/tests/queries/fragments.test.js
+++ b/test/tests/queries/fragments.test.js
@@ -6,9 +6,7 @@ describe('graphql - fragments', () => {
   const { axios, POST } = cds.test(path.join(__dirname, '../../resources/bookshop-graphql'))
   // Prevent axios from throwing errors for non 2xx status codes
   axios.defaults.validateStatus = false
-  axios.defaults.headers = {
-    authorization: 'Basic YWxpY2U6'
-  }
+  axios.defaults.headers.Authorization = 'Basic YWxpY2U6'
 
   // REVISIT: unskip for support of configurable schema flavors
   describe.skip('queries with fragments without connections', () => {

--- a/test/tests/queries/meta.test.js
+++ b/test/tests/queries/meta.test.js
@@ -6,9 +6,7 @@ describe('graphql - meta fields', () => {
   const { axios, POST } = cds.test(path.join(__dirname, '../../resources/bookshop-graphql'))
   // Prevent axios from throwing errors for non 2xx status codes
   axios.defaults.validateStatus = false
-  axios.defaults.headers = {
-    authorization: 'Basic YWxpY2U6'
-  }
+  axios.defaults.headers.Authorization = 'Basic YWxpY2U6'
 
   // REVISIT: unskip for support of configurable schema flavors
   describe.skip('queries with __typename meta field without connections', () => {

--- a/test/tests/queries/orderBy.test.js
+++ b/test/tests/queries/orderBy.test.js
@@ -6,9 +6,7 @@ describe('graphql - orderBy', () => {
   const { axios, POST } = cds.test(path.join(__dirname, '../../resources/bookshop-graphql'))
   // Prevent axios from throwing errors for non 2xx status codes
   axios.defaults.validateStatus = false
-  axios.defaults.headers = {
-    authorization: 'Basic YWxpY2U6'
-  }
+  axios.defaults.headers.Authorization = 'Basic YWxpY2U6'
 
   // REVISIT: unskip for support of configurable schema flavors
   describe.skip('queries with orderBy argument without connections', () => {

--- a/test/tests/queries/paging-offset.test.js
+++ b/test/tests/queries/paging-offset.test.js
@@ -6,9 +6,7 @@ describe('graphql - offset-based paging', () => {
   const { axios, POST } = cds.test(path.join(__dirname, '../../resources/bookshop-graphql'))
   // Prevent axios from throwing errors for non 2xx status codes
   axios.defaults.validateStatus = false
-  axios.defaults.headers = {
-    authorization: 'Basic YWxpY2U6'
-  }
+  axios.defaults.headers.Authorization = 'Basic YWxpY2U6'
 
   // REVISIT: unskip for support of configurable schema flavors
   describe.skip('queries with paging arguments without connections', () => {

--- a/test/tests/queries/queries.test.js
+++ b/test/tests/queries/queries.test.js
@@ -6,9 +6,7 @@ describe('graphql - queries', () => {
   const { axios, POST, data } = cds.test(path.join(__dirname, '../../resources/bookshop-graphql'))
   // Prevent axios from throwing errors for non 2xx status codes
   axios.defaults.validateStatus = false
-  axios.defaults.headers = {
-    authorization: 'Basic YWxpY2U6'
-  }
+  axios.defaults.headers.Authorization = 'Basic YWxpY2U6'
 
   beforeEach(async () => {
     await data.reset()

--- a/test/tests/queries/totalCount.test.js
+++ b/test/tests/queries/totalCount.test.js
@@ -6,9 +6,7 @@ describe('graphql - queries with totalCount', () => {
   const { axios, POST } = cds.test(path.join(__dirname, '../../resources/bookshop-graphql'))
   // Prevent axios from throwing errors for non 2xx status codes
   axios.defaults.validateStatus = false
-  axios.defaults.headers = {
-    authorization: 'Basic YWxpY2U6'
-  }
+  axios.defaults.headers.Authorization = 'Basic YWxpY2U6'
 
   test('simple query with totalCount', async () => {
     const query = gql`

--- a/test/tests/queries/variables.test.js
+++ b/test/tests/queries/variables.test.js
@@ -6,9 +6,7 @@ describe('graphql - variables', () => {
   const { axios, POST } = cds.test(path.join(__dirname, '../../resources/bookshop-graphql'))
   // Prevent axios from throwing errors for non 2xx status codes
   axios.defaults.validateStatus = false
-  axios.defaults.headers = {
-    authorization: 'Basic YWxpY2U6'
-  }
+  axios.defaults.headers.Authorization = 'Basic YWxpY2U6'
 
   // REVISIT: unskip for support of configurable schema flavors
   describe.skip('queries with variables without connections', () => {


### PR DESCRIPTION
The Axios shim in the upcoming `cds-test` 1.0.0 initially failed due to the Content-Type header being overwritten by all tests here. We will provide compatibilty, but it's better nonetheless to not overwrite headers.

Also not hard-wire a JSON parsing error message from Axios in tests.