### PR TITLE
chore: Prepare for upcoming release of `@sap/cds`

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-package-lock=false

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "prettier": "npm_config_yes=true npx prettier@latest --write app lib test",
     "prettier:check": "npm_config_yes=true npx prettier@latest --check app lib test",
     "lint": "npm_config_yes=true npx eslint@latest .",
-    "test": "jest --silent",
+    "test": "npx jest --silent",
     "test:generate-schemas": "node ./test/scripts/generate-schemas.js"
   },
   "dependencies": {
@@ -39,9 +39,8 @@
     "@sap/cds": ">=9"
   },
   "devDependencies": {
-    "@cap-js/graphql": "file:.",
-    "@cap-js/sqlite": ">=2",
     "@cap-js/cds-test": ">=0",
-    "jest": "^30"
+    "@cap-js/graphql": "file:.",
+    "@cap-js/sqlite": ">=2"
   }
 }

--- a/test/resources/error-handling/i18n/messages_en.properties
+++ b/test/resources/error-handling/i18n/messages_en.properties
@@ -1,1 +1,5 @@
 ORDER_EXCEEDS_STOCK=The order of {0} books exceeds the stock by {1}
+MULTIPLE_ERRORS=Multiple errors have occurred.
+ASSERT_NOT_NULL=Value is required
+
+MY_CODE=My custom error code

--- a/test/tests/error-handling-dev.test.js
+++ b/test/tests/error-handling-dev.test.js
@@ -176,7 +176,7 @@ describe('graphql - error handling in development', () => {
         {
           message: 'Error on READ A',
           extensions: {
-            code: '',
+            code: expect.stringMatching(/^(|500)$/),
             myProperty: 'My value A1',
             $myProperty: 'My value A2',
             my: { nested: { property: 'My value A3' } },
@@ -206,7 +206,7 @@ describe('graphql - error handling in development', () => {
         {
           message: 'Error on READ B',
           extensions: {
-            code: '',
+            code: expect.stringMatching(/^(|500)$/),
             stacktrace: expect.any(Array)
           }
         }
@@ -232,7 +232,7 @@ describe('graphql - error handling in development', () => {
         {
           message: 'Error on READ C',
           extensions: {
-            code: '',
+            code: expect.stringMatching(/^(|500)$/),
             stacktrace: expect.any(Array)
           }
         }
@@ -408,7 +408,7 @@ describe('graphql - error handling in development', () => {
         {
           message: 'The order of 20 books exceeds the stock by 10',
           extensions: {
-            code: '400',
+            code: expect.stringMatching(/^(400|ORDER_EXCEEDS_STOCK)$/),
             args: [20, 10],
             stacktrace: expect.any(Array)
           }
@@ -437,7 +437,7 @@ describe('graphql - error handling in development', () => {
         {
           message: 'The order of 20 books exceeds the stock by 10',
           extensions: {
-            code: '',
+            code: expect.stringMatching(/^(|ORDER_EXCEEDS_STOCK)$/),
             target: 'ORDER_EXCEEDS_STOCK',
             args: [20, 10],
             stacktrace: expect.any(Array)

--- a/test/tests/error-handling-prod.test.js
+++ b/test/tests/error-handling-prod.test.js
@@ -396,7 +396,7 @@ describe('graphql - error handling in production', () => {
         {
           message: 'The order of 20 books exceeds the stock by 10',
           extensions: {
-            code: '400'
+            code: expect.stringMatching(/400|ORDER_EXCEEDS_STOCK/)
           }
         }
       ]

--- a/test/tests/http.test.js
+++ b/test/tests/http.test.js
@@ -27,7 +27,7 @@ describe('GraphQL express json parser error scenario', () => {
     } catch (err) {
       expect(err.status).toBe(400)
       expect(err.response.data.error.message).toMatch(/JSON/i)
-      expect(_format(_error[0])).toContain('InvalidJSON')
+      expect(_format(_error[0])).toContain('Expected property name or \'}\' in JSON at position 2')
     }
   })
 })

--- a/test/tests/http.test.js
+++ b/test/tests/http.test.js
@@ -27,7 +27,7 @@ describe('GraphQL express json parser error scenario', () => {
     } catch (err) {
       expect(err.status).toBe(400)
       expect(err.response.data.error.message).toMatch(/JSON/i)
-      expect(_format(_error[0])).toContain('Expected property name or \'}\' in JSON at position 2')
+      expect(_format(_error[0])).toMatch(/Invalid ?JSON/)
     }
   })
 })


### PR DESCRIPTION
- The fixed tests were too much snapshot tests instead of checking for really expected data. 
- Custom error messages need to be in default language bundle as well. 
- Avoid project-local `.npmrc` in all CAP projects please
- Avoid dev dependencies for `jest` in all CAP projects please