### PR TITLE
chore: support `[affected]`

### DIFF
--- a/lib/resolvers/crud/create.js
+++ b/lib/resolvers/crud/create.js
@@ -6,6 +6,11 @@ const { entriesStructureToEntityStructure } = require('./utils')
 const GraphQLRequest = require('../GraphQLRequest')
 const formatResult = require('../parse/ast/result')
 
+const _only_keys = (entity, data) => {
+  const entity_keys = Object.assign(entity.keys ?? {}, { IsActiveEntity: 1 })
+  return data.every(d => Object.keys(d).every(k => k in entity_keys))
+}
+
 module.exports = async ({ req, res }, service, entity, selection) => {
   let query = INSERT.into(entity)
 
@@ -15,18 +20,8 @@ module.exports = async ({ req, res }, service, entity, selection) => {
 
   const cdsReq = new GraphQLRequest({ req, res, query })
   let result = await service.dispatch(cdsReq)
-  if (typeof result === 'object' && 'affectedRows' in result) {
-    let only_keys = true
-    const entity_keys = Object.keys(entity.keys ?? {})
-    for (let i = 0; i < result.data.length; i++) {
-      const data_keys = Object.keys(result.data[i])
-      if (!data_keys.every(k => entity_keys.includes(k))) {
-        only_keys = false
-        break
-      }
-    }
-    if (only_keys) result = cdsReq.data
-    else result = result.data
+  if (Array.isArray(result) && 'affected' in result) {
+    result = !_only_keys(entity, result) ? result : cdsReq.data
   }
 
   return formatResult(entity, selection, result, false)

--- a/lib/resolvers/crud/create.js
+++ b/lib/resolvers/crud/create.js
@@ -7,7 +7,7 @@ const GraphQLRequest = require('../GraphQLRequest')
 const formatResult = require('../parse/ast/result')
 
 const _only_keys = (entity, data) => {
-  const entity_keys = Object.assign(entity.keys ?? {}, { IsActiveEntity: 1 })
+  const entity_keys = { ...(entity.keys ?? {}), IsActiveEntity: 1 }
   return data.every(d => Object.keys(d).every(k => k in entity_keys))
 }
 

--- a/lib/resolvers/crud/delete.js
+++ b/lib/resolvers/crud/delete.js
@@ -14,7 +14,7 @@ module.exports = async ({ req, res }, service, entity, selection) => {
   let result
   try {
     result = await service.dispatch(new GraphQLRequest({ req, res, query }))
-    if (typeof result === 'object' && 'affectedRows' in result) result = result.affectedRows
+    if (Array.isArray(result) && 'affected' in result) result = result.affected
   } catch (e) {
     if (e.code === 404) result = 0
     else throw e

--- a/lib/resolvers/crud/update.js
+++ b/lib/resolvers/crud/update.js
@@ -32,7 +32,7 @@ module.exports = async ({ req, res }, service, entity, selection) => {
 
     const cdsReq = new GraphQLRequest({ req, res, query })
     let result = await service.dispatch(cdsReq)
-    if (typeof result === 'object' && 'affectedRows' in result) result = result.data ?? cdsReq.data
+    if (Array.isArray(result) && 'affected' in result) result = result.length ? result : cdsReq.data
     return result
   })
 


### PR DESCRIPTION
# Chore: Support `[affected]` Array Format in CRUD Resolvers

### Refactor

♻️ Updated the CRUD resolvers (`create`, `update`, `delete`) to handle the new `[affected]` array format returned by CDS, replacing the previous `affectedRows`-based result structure.

### Changes

* `lib/resolvers/crud/create.js`: Extracted a helper function `_only_keys` to check if result data contains only entity key fields (including `IsActiveEntity`). Updated result handling to check `Array.isArray(result) && 'affected' in result` instead of `typeof result === 'object' && 'affectedRows' in result`. Simplified the conditional logic for determining whether to use the request data or the result directly.

* `lib/resolvers/crud/delete.js`: Updated result handling to extract `result.affected` instead of `result.affectedRows` when the result is an array with an `affected` property.

* `lib/resolvers/crud/update.js`: Updated result handling to use the new `[affected]` array check, and replaced `result.data ?? cdsReq.data` with `result.length ? result : cdsReq.data` to determine the correct return value.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.20.51`

- File Content Strategy: Full file content
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- Correlation ID: `7af88f27-a399-4d8f-9cb1-231d7fb77074`
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Event Trigger: `pull_request.edited`
- LLM: `anthropic--claude-4.6-sonnet`
</details>
